### PR TITLE
feat: add `ENV.accessed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Note: attempts to update the environment (`[]=`) will apply this as an env var.
 Secrets are immutable.
 Once set as env vars take preference over secrets, the new value is readable by the current machine, but is ephemeral.
 
+Additionally, `ENV.accessed` is a compile-time record of all accesses to the `ENV` variable across the program.
 
 ## Contributing
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: secrets-env
-version: 1.0.0
+version: 1.1.0
 
 development_dependencies:
   ameba:
@@ -7,7 +7,8 @@ development_dependencies:
 
 authors:
   - Kim Burgess <kim@place.technology>
+  - Caspian Baska <caspian@place.technology>
 
-crystal: 0.34.0
+crystal: 0.34
 
 license: MIT

--- a/spec/secrets-env_spec.cr
+++ b/spec/secrets-env_spec.cr
@@ -1,6 +1,7 @@
+require "../src/secrets-env"
+
 require "spec"
 require "file"
-require "../src/secrets-env"
 
 original_secrets_path = nil
 
@@ -25,6 +26,18 @@ describe ENV do
       tmp_name = Path[tmp.path].basename
       ENV[tmp_name].should eq("hunter2")
       tmp.delete
+    end
+  end
+
+  describe "accessed" do
+    it "includes environment variables accessed by non-strict lookups" do
+      ENV["HELLO"]?
+      ENV.accessed.should contain("HELLO")
+    end
+
+    it "includes environment variables accessed by strict lookups" do
+      ENV["SECRETS_PATH"]
+      ENV.accessed.should contain("SECRETS_PATH")
     end
   end
 end

--- a/src/secrets-env.cr
+++ b/src/secrets-env.cr
@@ -4,6 +4,25 @@ require "path"
 module ENV
   DEFAULT_SECRETS_PATH = "/run/secrets"
 
+  # :nodoc:
+  ACCESSED = [] of String
+
+  # Returns a compile-time generated array of each environment variable
+  # accessed by the program.
+  def self.accessed : Array(String)
+    ACCESSED
+  end
+
+  macro [](key)
+    {{ ACCESSED << key if key.is_a? StringLiteral && !ACCESSED.includes? key }}
+    ENV.fetch({{ key }})
+  end
+
+  macro []?(key)
+    {{ ACCESSED << key if key.is_a? StringLiteral && !ACCESSED.includes? key }}
+    ENV.fetch({{ key }}, nil)
+  end
+
   # Retrieves a value corresponding to a given *key*. The value will be
   # retrieved from (in order of priorities): system env vars, available secrets
   # files or the return value of the block.


### PR DESCRIPTION
`ENV.accessed` is a compile-time generated array of all environment keys
accessed by the program.