### PR TITLE
Support crystal 0.36.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Note: attempts to update the environment (`[]=`) will apply this as an env var.
 Secrets are immutable.
 Once set as env vars take preference over secrets, the new value is readable by the current machine, but is ephemeral.
 
-Additionally, `ENV.accessed` is a compile-time record of all accesses to the `ENV` variable across the program.
+Additionally, `ENV.accessed` provides a record of all accesses to the `ENV` variable across the program.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: secrets-env
-version: 1.2.0
+version: 1.2.1
 
 development_dependencies:
   ameba:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: secrets-env
-version: 1.2.1
+version: 1.3.0
 
 development_dependencies:
   ameba:

--- a/spec/secrets-env_spec.cr
+++ b/spec/secrets-env_spec.cr
@@ -103,32 +103,31 @@ describe ENV do
   end
 
   describe ".accessed" do
-    context "static resolution" do
-      it "supports non-strict lookups" do
-        {% if compare_versions(Crystal::VERSION, "0.36.0") >= 0 %}
-          pending! "Static only ENV.accessed unavailable on #{Crystal::VERSION} for non-strict lookups"
-        {% end %}
-        ENV.accessed.should contain("SECRETS_ENV_NON_STRICT_TEST")
-        ENV["SECRETS_ENV_NON_STRICT_TEST"]?
-      end
+    {% if compare_versions(Crystal::VERSION, "0.36.0") == 0 %}
+      pending "static resolution (unavailable on #{Crystal::VERSION})"
+    {% else %}
+      context "static resolution" do
+        it "supports non-strict lookups" do
+          ENV.accessed.should contain("SECRETS_ENV_NON_STRICT_TEST")
+          ENV["SECRETS_ENV_NON_STRICT_TEST"]?
+        end
 
-      it "supports strict lookups" do
-        ENV.accessed.should contain("SECRETS_ENV_STRICT_TEST")
-        ENV["SECRETS_ENV_STRICT_TEST"] rescue nil
+        it "supports strict lookups" do
+          ENV.accessed.should contain("SECRETS_ENV_STRICT_TEST")
+          ENV["SECRETS_ENV_STRICT_TEST"] rescue nil
+        end
       end
-    end
+    {% end %}
 
     it "includes runtime lookups" do
       runtime_key = ->{ "SECRETS_ENV_RUNTIME_TEST" }.call
       ENV.accessed.should_not contain(runtime_key)
       ENV[runtime_key]?
       ENV.accessed.should contain(runtime_key)
-      {% if compare_versions(Crystal::VERSION, "0.36.0") < 0 %}
-        ENV.accessed(static_only: true).should_not contain(runtime_key)
+      {% if compare_versions(Crystal::VERSION, "0.36.0") == 0 %}
+        expect_raises(Exception) { ENV.accessed(static_only: true) }
       {% else %}
-        expect_raises(Exception) do
-          ENV.accessed(static_only: true)
-        end
+        ENV.accessed(static_only: true).should_not contain(runtime_key)
       {% end %}
     end
   end

--- a/spec/secrets-env_spec.cr
+++ b/spec/secrets-env_spec.cr
@@ -103,32 +103,19 @@ describe ENV do
   end
 
   describe ".accessed" do
-    {% if compare_versions(Crystal::VERSION, "0.36.0") == 0 %}
-      pending "static resolution (unavailable on #{Crystal::VERSION})"
-    {% else %}
-      context "static resolution" do
-        it "supports non-strict lookups" do
-          ENV.accessed.should contain("SECRETS_ENV_NON_STRICT_TEST")
-          ENV["SECRETS_ENV_NON_STRICT_TEST"]?
-        end
+    it "tracks non-strict lookups" do
+      ENV["SECRETS_ENV_NON_STRICT_TEST"]?
+      ENV.accessed.should contain("SECRETS_ENV_NON_STRICT_TEST")
+    end
 
-        it "supports strict lookups" do
-          ENV.accessed.should contain("SECRETS_ENV_STRICT_TEST")
-          ENV["SECRETS_ENV_STRICT_TEST"] rescue nil
-        end
-      end
-    {% end %}
+    it "tracks strict lookups" do
+      ENV["SECRETS_ENV_STRICT_TEST"] rescue nil
+      ENV.accessed.should contain("SECRETS_ENV_STRICT_TEST")
+    end
 
-    it "includes runtime lookups" do
-      runtime_key = ->{ "SECRETS_ENV_RUNTIME_TEST" }.call
-      ENV.accessed.should_not contain(runtime_key)
-      ENV[runtime_key]?
-      ENV.accessed.should contain(runtime_key)
-      {% if compare_versions(Crystal::VERSION, "0.36.0") == 0 %}
-        expect_raises(Exception) { ENV.accessed(static_only: true) }
-      {% else %}
-        ENV.accessed(static_only: true).should_not contain(runtime_key)
-      {% end %}
+    it "tracks enumerations" do
+      ENV.each { }
+      ENV.accessed.should contain("CRYSTAL_PATH")
     end
   end
 end

--- a/src/secrets-env.cr
+++ b/src/secrets-env.cr
@@ -5,50 +5,26 @@ require "set"
 module ENV
   DEFAULT_SECRETS_PATH = "/run/secrets"
 
-  private STATIC_ACCESSED = [] of String
+  private ACCESSED = Set(String).new
 
-  macro finished
-    private ACCESSED = STATIC_ACCESSED.to_set
+  # Returns the set of all environment variables or secrets  that have been
+  # accessed by the program.
+  def self.accessed : Array(String)
+    ACCESSED.to_a
   end
 
-  # Returns the set of all environment variables accessed by the program.
-  #
-  # Items that can be statically resolved will be provided at compile time, with
-  # dynamic access appended following usage.
-  def self.accessed(static_only = false) : Array(String)
-    if static_only
-      STATIC_ACCESSED.dup
-    else
-      ACCESSED.to_a
-    end
+  @[Deprecated("Static resolution no longer supported")]
+  def self.accessed(static_only) : Array(String)
+    raise "Static resolution no longer supported" if static_only
+    ACCESSED.to_a
   end
 
-  # Workaround for a regressions in crystal-lang 0.36.0.
-  # https://github.com/crystal-lang/crystal/pull/10338
-  {% if compare_versions(Crystal::VERSION, "0.36.0") == 0 %}
-    def self.accessed(static_only = false) : Array(String)
-      raise "Static only ENV.accessed is not supported on #{Crystal::VERSION}" if static_only
-      previous_def
+  def self.each
+    previous_def do |key, value|
+      ACCESSED << key
+      yield({key, value})
     end
-  {% else %}
-    {% verbatim do %}
-      # Override `.[]` to enable compile-time resolution or accessed keys.
-      #
-      # Maintains the behaviour of the method of the same name.
-      macro [](key)
-        {{ STATIC_ACCESSED << key if key.is_a? StringLiteral && !STATIC_ACCESSED.includes? key }}
-        ENV.fetch({{ key }})
-      end
-
-      # Override `.[]?` to enable compile-time resolution or accessed keys.
-      #
-      # Maintains the behaviour of the method of the same name.
-      macro []?(key)
-        {{ STATIC_ACCESSED << key if key.is_a? StringLiteral && !STATIC_ACCESSED.includes? key }}
-        ENV.fetch({{ key }}, nil)
-      end
-    {% end %}
-  {% end %}
+  end
 
   # Retrieves a value corresponding to a given *key*. The value will be
   # retrieved from (in order of priorities): system env vars, available secrets


### PR DESCRIPTION
Narrows special case behaviour introduced in #4 to crystal 0.36.0 only.

Support for operator based macro's re-introduced to compiler.